### PR TITLE
agent: server: fix swag install path for cross-arch builds

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -69,7 +69,7 @@ swag swagger: ## Generate Swagger Documentation
 	    go_path=`echo $$cygdrive_prefix/$$drive/$$path | sed 's@\/\/@\/@g'`; \
 	  fi; \
 	  if [ ! -f "$$go_path/bin/swag" ]; then \
-	    ${GO_COMMAND} install github.com/swaggo/swag/cmd/swag@latest; \
+	    GOOS= GOARCH= ${GO_COMMAND} install github.com/swaggo/swag/cmd/swag@latest; \
 	  fi; \
 	  $$go_path/bin/swag init -g ./pkg/api/rest/server/server.go --pd -o ./pkg/api/rest/docs/ > /dev/null
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -69,7 +69,7 @@ swag swagger: ## Generate Swagger Documentation
 	    go_path=`echo $$cygdrive_prefix/$$drive/$$path | sed 's@\/\/@\/@g'`; \
 	  fi; \
 	  if [ ! -f "$$go_path/bin/swag" ]; then \
-	    ${GO_COMMAND} install github.com/swaggo/swag/cmd/swag@latest; \
+	    GOOS= GOARCH= ${GO_COMMAND} install github.com/swaggo/swag/cmd/swag@latest; \
 	  fi; \
 	  $$go_path/bin/swag init -g ./pkg/api/rest/server/server.go --pd -o ./pkg/api/rest/docs/ > /dev/null
 


### PR DESCRIPTION
## Problem

CD (`Continuous Delivery`) fails on the multi-arch container image build. The `linux/arm64` build errors out while the `linux/amd64` build is only canceled as a side effect:

```
#35 [linux/amd64->arm64 builder 11/11] RUN GOOS=linux GOARCH=arm64 make build-only
#35 /bin/bash: line 12: /go/bin/swag: No such file or directory
#35 make: *** [Makefile:63: swag] Error 127
```

## Root cause

The Dockerfile runs the toolchain on the native `$BUILDPLATFORM` (amd64) and cross-compiles to the target platform:

```dockerfile
RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-only
```

`build-only` depends on the `swag` target, which runs `go install github.com/swaggo/swag/cmd/swag@latest` with `GOOS`/`GOARCH` still inherited from the environment. When the target arch differs from the host (cross-compilation, e.g. `GOARCH=arm64` on an amd64 host), Go installs the binary under `$GOPATH/bin/<GOOS>_<GOARCH>/swag` instead of `$GOPATH/bin/swag`. The very next line then calls `$go_path/bin/swag init` → `/go/bin/swag` → not found → exit 127.

The amd64 build succeeds because its target arch matches the host, so `swag` lands directly in `/go/bin/swag`.

## Fix

Install `swag` with the host toolchain by clearing `GOOS`/`GOARCH` for that single `go install`, so the tool binary always lands in `$GOPATH/bin/swag`. The application build itself keeps cross-compiling to the target platform.

Applied identically to `server/Makefile` and `agent/Makefile` since they share the same recipe.